### PR TITLE
Update scapy

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,7 @@ setup(
         "lockfile>=0.12",
         "pip>=8.1",
         "pyroute2>=0.3",
-        'scapy-python3>=0.20',
+        'scapy>=2.4.0',
     ],
     python_requires=">=3.5",
     extras_require={


### PR DESCRIPTION
scapy-python3 is an unofficial fork that is getting very oudated (many bug fixes missing).
Migrates to original and up-to-date scapy, which now supports python 3